### PR TITLE
fix: list-all cmd does not working.

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -14,7 +14,7 @@ sort_versions() {
 }
 
 list_versions() {
-	cmd="curl -fsS --url $RELEASES_URL"
+	cmd="curl -fsSL --url $RELEASES_URL"
 	[ -n "$GITHUB_API_TOKEN" ] && cmd+=" -H 'Authorization: token $GITHUB_API_TOKEN'"
 
 	echo "$(eval $cmd | grep -oE "tag_name\": *\"v[0-9].*\"," | sed 's/tag_name\": *\"v//;s/\",//')"

--- a/bin/list-all
+++ b/bin/list-all
@@ -6,7 +6,7 @@ set -o pipefail
 
 : "${GITHUB_API_TOKEN:=""}"
 
-readonly RELEASES_URL="https://api.github.com/repos/google/ko/releases"
+readonly RELEASES_URL="https://api.github.com/repositories/177010499/releases"
 
 sort_versions() {
 	sed 'h; s/[+-]/./g; s/.p\([[:digit:]]\)/.z.\1/; s/$/.z/; G; s/\n/ /' | \


### PR DESCRIPTION
Now, getting url for release info of ko is moved.
So, i fixed url and curl command(for process 301 with curl).

```
❯ curl -fsS --url https://api.github.com/repos/google/ko/releases       
{
  "message": "Moved Permanently",
  "url": "https://api.github.com/repositories/177010499/releases",
  "documentation_url": "https://docs.github.com/v3/#http-redirects"
}
```